### PR TITLE
⚡ Change Webhook Endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-01-29
+
+### Changes
+
+- Change of the Webhook endpoint to `/webhook` for consistency
+- New `/ping` endpoint for health checks
+- New `/version` endpoint for version information
+
 ## [1.0.0] - 2025-01-27
 
 ### Added
+
 - Initial release
 - Webhook endpoint for KoFi notifications
 - WebSocket endpoint with verification token

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,10 @@ class KofiWebhook(BaseModel):
 async def ping():
     return {"message": "pong"}
 
+@app.get("/version")
+async def version():
+    return {"version": app.version}
+
 @app.post("/webhook")
 async def ko_fi_webhook(webhook_data: KofiWebhook):
     """Handle incoming Ko-fi webhook data and forward it to connected WebSocket clients."""

--- a/app/main.py
+++ b/app/main.py
@@ -71,7 +71,7 @@ class KofiWebhook(BaseModel):
 async def ping():
     return {"message": "pong"}
 
-@app.post("/webhook/ko-fi")
+@app.post("/webhook")
 async def ko_fi_webhook(webhook_data: KofiWebhook):
     """Handle incoming Ko-fi webhook data and forward it to connected WebSocket clients."""
     verification_token = webhook_data.data.verification_token

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import json
 
 app = FastAPI(
-    version="1.0.0",
+    version="1.0.1",
     docs_url=None,  # Disable Swagger UI
     redoc_url=None  # Disable ReDoc
 )
@@ -66,6 +66,10 @@ class KofiData(BaseModel):
 
 class KofiWebhook(BaseModel):
     data: KofiData
+
+@app.get("/ping")
+async def ping():
+    return {"message": "pong"}
 
 @app.post("/webhook/ko-fi")
 async def ko_fi_webhook(webhook_data: KofiWebhook):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    container_name: kofi-websocket
+    image: lordlumineer/kofi-websocket:latest
+    restart: unless-stopped
+    ports:
+      - "8000:8000"

--- a/test_client.html
+++ b/test_client.html
@@ -124,7 +124,7 @@
                 }
             };
 
-            fetch(`${baseUrl}/webhook/ko-fi`, {
+            fetch(`${baseUrl}/webhook`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,7 +59,7 @@ def sample_shop_webhook_data(sample_webhook_data):
 
 
 def test_webhook_without_active_connection(client, sample_webhook_data):
-    response = client.post("/webhook/ko-fi", json=sample_webhook_data)
+    response = client.post("/webhook", json=sample_webhook_data)
     assert response.status_code == 200
     assert response.json() == {"status": "success"}
 
@@ -78,12 +78,12 @@ async def test_webhook_with_active_connection(client, sample_webhook_data):
         sample_webhook_data["data"]["verification_token"] = "test_token"
         # Ensure timestamp is a string
         sample_webhook_data["data"]["timestamp"] = datetime.now().isoformat()
-        response = client.post("/webhook/ko-fi", json=sample_webhook_data)
+        response = client.post("/webhook", json=sample_webhook_data)
         assert response.status_code == 200
 
 
 def test_shop_order_webhook(client, sample_shop_webhook_data):
-    response = client.post("/webhook/ko-fi", json=sample_shop_webhook_data)
+    response = client.post("/webhook", json=sample_shop_webhook_data)
     assert response.status_code == 200
     assert response.json() == {"status": "success"}
 
@@ -149,7 +149,7 @@ async def test_webhook_connection_error_retry(client, sample_webhook_data):
         try:
             # Update verification token to match WebSocket connection
             sample_webhook_data["data"]["verification_token"] = "test_token"
-            response = client.post("/webhook/ko-fi", json=sample_webhook_data)
+            response = client.post("/webhook", json=sample_webhook_data)
             assert response.status_code == 200
             assert error_count > 1  # Verify that retries occurred
         finally:
@@ -172,7 +172,7 @@ async def test_webhook_max_retries_exceeded(client, sample_webhook_data):
         try:
             # Update verification token to match WebSocket connection
             sample_webhook_data["data"]["verification_token"] = "test_token"
-            response = client.post("/webhook/ko-fi", json=sample_webhook_data)
+            response = client.post("/webhook", json=sample_webhook_data)
             assert response.status_code == 200
             # Import the active_connections from main module
             from app.main import active_connections
@@ -199,7 +199,7 @@ async def test_webhook_websocket_disconnect(client, sample_webhook_data):
         try:
             # Update verification token to match WebSocket connection
             sample_webhook_data["data"]["verification_token"] = "test_token"
-            response = client.post("/webhook/ko-fi", json=sample_webhook_data)
+            response = client.post("/webhook", json=sample_webhook_data)
             assert response.status_code == 200
             # Import the active_connections from main module
             from app.main import active_connections
@@ -208,3 +208,9 @@ async def test_webhook_websocket_disconnect(client, sample_webhook_data):
         finally:
             # Restore original method
             WebSocket.send_json = original_send_json
+
+
+def test_ping_endpoint(client):
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"message": "pong"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -214,3 +214,9 @@ def test_ping_endpoint(client):
     response = client.get("/ping")
     assert response.status_code == 200
     assert response.json() == {"message": "pong"}
+
+
+def test_version_endpoint(client):
+    response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": app.version}


### PR DESCRIPTION
- Change of the Webhook endpoint to `/webhook` for consistency
- New `/ping` endpoint for health checks
- New `/version` endpoint for version information