### PR TITLE
⚡ v1.0.1 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,62 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual Environment
+venv/
+ENV/
+.env
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Docker
+Dockerfile
+docker-compose*.yml
+
+# Documentation
+docs/
+*.md
+LICENSE
+
+# Development
+test_client.html
+tests/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+static/index.html -linguist-documentation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the issue where the homepage displayed two semicolons after the protocol (e.g. `https:://` is now `https://`)
 - Added the version number to the homepage
+- Removed the HomePage and test client html files from the github code count (linguist)
+- Added `.dockerignore` file to exclude the unnecessary files from the docker image
 
 ## [1.0.0] - 2025-02-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-02-01
+
+### Changes
+
+- Fixed the issue where the homepage displayed two semicolons after the protocol (e.g. `https:://` is now `https://`)
+- Added the version number to the homepage
+
 ## [1.0.0] - 2025-02-01
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ from starlette.middleware.cors import CORSMiddleware
 active_connections: dict[str, WebSocket] = {}
 
 app = FastAPI(
-    version="1.0.0",
+    version="1.0.1",
     docs_url=None,  # Disable Swagger UI
     redoc_url=None  # Disable ReDoc
 )

--- a/static/index.html
+++ b/static/index.html
@@ -337,13 +337,28 @@
         .glass-card ol li {
             margin-bottom: 0.25rem;
         }
+
+        .version-badge {
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-radius: 12px;
+            padding: 0.25rem 0.75rem;
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            transform: translateY(-2rem);
+            display: inline-block;
+        }
     </style>
 </head>
 
 <body>
     <div class="container">
         <header class="header glass-card">
-            <h1>Ko-Fi WebSocket Bridge</h1>
+            <h1>
+                Ko-Fi WebSocket Bridge
+                <br>
+                <div class="version-badge" id="version-badge">Loading version...</div>
+            </h1>
             <p class="description">
                 A modern, real-time bridge between Ko-fi webhooks and WebSocket connections, enabling instant
                 notifications for your Ko-fi events.
@@ -564,6 +579,17 @@ ws.onmessage = (event) => {
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 
     <script>
+        // Add this before the existing script content
+        fetch('/version')
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('version-badge').textContent = 'v' + data.version;
+            })
+            .catch(error => {
+                console.error('Error fetching version:', error);
+                document.getElementById('version-badge').textContent = 'Version unknown';
+            });
+
         document.querySelectorAll('.code-block').forEach(block => {
             const pre = block.querySelector('pre');
 

--- a/static/index.html
+++ b/static/index.html
@@ -579,7 +579,7 @@ ws.onmessage = (event) => {
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 
     <script>
-        // Add this before the existing script content
+        // Fetch the version from the server
         fetch('/version')
             .then(response => response.json())
             .then(data => {

--- a/static/index.html
+++ b/static/index.html
@@ -357,7 +357,7 @@
             <h2>Quick Start</h2>
             <p>Connect to the WebSocket endpoint using your verification token:</p>
             <div class="code-block">
-                <pre>{{ WSprotocol }}://{{ HOSTNAME }}/ws/{verification_token}</pre>
+                <pre>{{ WSprotocol }}//{{ HOSTNAME }}/ws/{verification_token}</pre>
             </div>
         </section>
 
@@ -396,13 +396,13 @@
             <h3>2. Set Up Ko-fi Webhook</h3>
             <p>In your Ko-fi settings, set your Webhook URL to:</p>
             <div class="code-block">
-                <pre id="webhook-url">{{ HTTPprotocol }}://{{ HOSTNAME }}/webhook</pre>
+                <pre id="webhook-url">{{ HTTPprotocol }}//{{ HOSTNAME }}/webhook</pre>
             </div>
 
             <h3>3. Connect to WebSocket</h3>
             <p>Connect to the WebSocket using your verification token:</p>
             <div class="code-block">
-                <pre>const ws = new WebSocket('{{ WSprotocol }}://{{ HOSTNAME }}/ws/YOUR_VERIFICATION_TOKEN');</pre>
+                <pre>const ws = new WebSocket('{{ WSprotocol }}//{{ HOSTNAME }}/ws/YOUR_VERIFICATION_TOKEN');</pre>
             </div>
 
             <h3>4. Handle Events</h3>
@@ -442,7 +442,7 @@ ws.onmessage = (event) => {
             }
 
             connect() {
-                this.ws = new WebSocket(`{{ WSprotocol }}://{{ HOSTNAME }}/ws/${this.token}`);
+                this.ws = new WebSocket(`{{ WSprotocol }}//{{ HOSTNAME }}/ws/${this.token}`);
 
                 this.ws.onopen = () => {
                     console.log('Connected to Ko-fi WebSocket');


### PR DESCRIPTION
- Fixed the issue where the homepage displayed two semicolons after the protocol (e.g. `https:://` is now `https://`)
- Added the version number to the homepage
- Removed the HomePage and test client html files from the github code count (linguist)
- Added `.dockerignore` file to exclude the unnecessary files from the docker image